### PR TITLE
fix validator not setting weights

### DIFF
--- a/validators/base_validator.py
+++ b/validators/base_validator.py
@@ -26,13 +26,13 @@ class BaseValidator(ABC):
         return uid, responses
 
     @abstractmethod
-    async def start_query(self, available_uids):
+    async def start_query(self, available_uids, metagraph):
         pass
 
     @abstractmethod
-    async def score_responses(self, responses):
+    async def score_responses(self, query_responses, uid_to_question, metagraph):
         pass
 
+    @abstractmethod
     async def get_and_score(self, available_uids, metagraph):
-        responses = await self.start_query(available_uids, metagraph)
-        return await self.score_responses(query_responses, uid_to_question, metagraph)
+        pass


### PR DESCRIPTION
no validators appear to be setting weights on the subnet. these changes appear to fix this issue. I am currently running these changes live on subnet 18 and will move this PR from draft state if weights are successfully set.