### PR TITLE
Sentry integration

### DIFF
--- a/cortext/reward.py
+++ b/cortext/reward.py
@@ -17,6 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
+import sentry_sdk
 from transformers import logging as hf_logging
 hf_logging.set_verbosity_error()
 
@@ -58,6 +59,7 @@ def calculate_text_similarity(text1: str, text2: str):
         bt.logging.debug(f"Similarity: {similarity}")
         return similarity
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error in calculate_text_similarity: {traceback.format_exc()}")
         raise
 
@@ -82,6 +84,7 @@ async def api_score(api_answer: str, response: str, weight: float, temperature: 
 
         return score
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Exception in api_score: {traceback.format_exc()}")
 
 
@@ -119,6 +122,7 @@ async def is_image_url(url: str) -> bool:
             async with session.head(url) as response:
                 return response.status == 200 and 'image' in response.headers.get('Content-Type', '')
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Error checking URL: {e}")
         return False
 
@@ -134,6 +138,7 @@ async def load_image_from_url(url: str):
                 image.verify()  # Verify that this is indeed an image
                 return image
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Failed to load image: {e}")
 
 
@@ -191,6 +196,7 @@ async def dalle_score(uid, url, desired_size, description, weight, similarity_th
         bt.logging.debug(f"UID {uid} failed similary test with score of: {round(similarity, 5)}. Score = {0}")
         return 0
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Error in image scoring for UID {uid}: {e}")
         return 0
 

--- a/cortext/sentry.py
+++ b/cortext/sentry.py
@@ -1,0 +1,22 @@
+from bittensor import config as Config
+import bittensor as bt
+import sentry_sdk
+
+from cortext import __version__
+
+def init_sentry(config : Config, tags : dict = {}):
+    if config.sentry_dsn is None:
+        bt.logging.info(f"Sentry is DISABLED")
+        return
+
+    bt.logging.info(f"Sentry is ENABLED. Using dsn={config.sentry_dsn}")
+    sentry_sdk.init(
+        dsn=config.sentry_dsn,
+        release=__version__,
+        environment=f"subnet #{config.netuid}",
+        traces_sample_rate=1.0,
+        profiles_sample_rate=1.0
+    )
+
+    for key, value in tags.items():
+        sentry_sdk.set_tag(key, value)

--- a/cortext/utils.py
+++ b/cortext/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sentry_sdk
 
 import io
 import ast
@@ -69,6 +70,7 @@ def load_state_from_file(filename: str):
                 load_success = True  # Set flag to true as the operation was successful
                 return state
             except Exception as e:  # Catch specific exceptions for better error handling
+                sentry_sdk.capture_exception()
                 bt.logging.error(f"error loading state, deleting and resetting it. Error: {e}")
                 os.remove(filename) # Delete if error
 
@@ -187,9 +189,11 @@ async def get_list(list_type, num_questions_needed, theme=None):
                             break
                         bt.logging.error(f"no list found in {new_answer}")
                     except Exception as e:
+                        sentry_sdk.capture_exception()
                         bt.logging.error(f"Exception on retry {retry + 1} for prompt '{selected_prompts[i]}': "
                                          f"{e}\n{traceback.format_exc()}")
         except Exception as e:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Exception in processing initial response for prompt '{selected_prompts[i]}': "
                              f"{e}\n{traceback.format_exc()}")
 
@@ -362,6 +366,7 @@ def extract_python_list(text: str):
                 return evaluated
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.error(f"found double quotes in list, trying again")
 
     return None
@@ -384,6 +389,7 @@ async def call_openai(messages, temperature, model, seed=1234, max_tokens=2048, 
             return response
 
         except Exception as e:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Error when calling OpenAI: {traceback.format_exc()}")
             await asyncio.sleep(0.5)
 
@@ -410,6 +416,7 @@ async def call_gemini(messages, temperature, model, max_tokens, top_p, top_k):
         print(f"validator response is {response.text}")
         return response.text
     except:
+        sentry_sdk.capture_exception()
         print(f"error in call_gemini {traceback.format_exc()}")
         
 
@@ -453,6 +460,7 @@ async def call_anthropic(prompt, temperature, model, max_tokens=2048, top_p=1, t
 
         return completion.completion
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error when calling Anthropic: {traceback.format_exc()}")
         await asyncio.sleep(0.5)
 
@@ -480,6 +488,7 @@ async def call_claude(messages, temperature, model, max_tokens, top_p, top_k):
         bt.logging.debug(f"validator response is {message.content[0].text}")
         return message.content[0].text
     except:
+        sentry_sdk.capture_exception()
         bt.logging.error(f"error in call_claude {traceback.format_exc()}")
 
 async def call_stability(prompt, seed, steps, cfg_scale, width, height, samples, sampler):
@@ -539,4 +548,5 @@ def send_discord_alert(message, webhook_url):
         else:
             print(f"Failed to send Discord alert. Status code: {response.status_code}")
     except Exception as e:
+        sentry_sdk.capture_exception()
         print(f"Failed to send Discord alert: {e}", exc_info=True)

--- a/miner/claude_miner.py
+++ b/miner/claude_miner.py
@@ -1,5 +1,6 @@
 import base  # noqa
 
+import sentry_sdk
 import argparse
 import asyncio
 import copy
@@ -201,6 +202,7 @@ class StreamMiner(ABC):
             return False, f"accepting {synapse_type} request from {hotkey}"
 
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"errror in blacklist {traceback.format_exc()}")
 
 
@@ -320,11 +322,13 @@ class StreamMiner(ABC):
                 step += 1
 
         except KeyboardInterrupt:
+            sentry_sdk.capture_exception()
             self.axon.stop()
             bt.logging.success("Miner killed by keyboard interrupt.")
             sys.exit()
 
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(traceback.format_exc())
 
     def run_in_background_thread(self) -> None:
@@ -395,6 +399,7 @@ class StreamingcortextMiner(StreamMiner):
             bt.logging.info(f"synapse response is {synapse.embeddings[0][:10]}")
             return synapse
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Exception in embeddings function: {traceback.format_exc()}")
 
 
@@ -463,6 +468,7 @@ class StreamingcortextMiner(StreamMiner):
             return synapse
 
         except Exception as exc:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"error in images: {exc}\n{traceback.format_exc()}")
 
     def prompt(self, synapse: StreamPrompting) -> StreamPrompting:
@@ -572,6 +578,7 @@ class StreamingcortextMiner(StreamMiner):
                     bt.logging.error(f"Unknown provider: {provider}")
 
             except Exception as e:
+                sentry_sdk.capture_exception()
                 bt.logging.error(f"error in _prompt {e}\n{traceback.format_exc()}")
 
         token_streamer = partial(_prompt, synapse)
@@ -618,12 +625,14 @@ def get_valid_hotkeys(config):
                         if hotkey not in valid_hotkeys:
                             valid_hotkeys.append(hotkey)
                     except Exception:
+                        sentry_sdk.capture_exception()
                         bt.logging.debug(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
 
             bt.logging.info(f"total valid hotkeys list = {valid_hotkeys}")
             time.sleep(180)
 
         except json.JSONDecodeError as e:
+            sentry_sdk.capture_exception()
             bt.logging.debug(f"JSON decoding error: {e} {run.id}")
 
 

--- a/miner/claude_miner.py
+++ b/miner/claude_miner.py
@@ -1,5 +1,6 @@
 import base  # noqa
 
+from cortext.sentry import init_sentry
 import sentry_sdk
 import argparse
 import asyncio
@@ -80,7 +81,7 @@ class StreamMiner(ABC):
         self.config = self.config()
         self.config.merge(base_config)
         check_config(StreamMiner, self.config)
-        init_sentry(self.config, {"neuron-type", "claude-miner"})
+        init_sentry(self.config, {"neuron-type": "claude-miner"})
         bt.logging.info(self.config)  # TODO: duplicate print?
         self.prompt_cache: dict[str, Tuple[str, int]] = {}
         self.request_timestamps = {}

--- a/miner/claude_miner.py
+++ b/miner/claude_miner.py
@@ -80,6 +80,7 @@ class StreamMiner(ABC):
         self.config = self.config()
         self.config.merge(base_config)
         check_config(StreamMiner, self.config)
+        init_sentry(self.config, {"neuron-type", "claude-miner"})
         bt.logging.info(self.config)  # TODO: duplicate print?
         self.prompt_cache: dict[str, Tuple[str, int]] = {}
         self.request_timestamps = {}
@@ -362,7 +363,7 @@ class StreamingcortextMiner(StreamMiner):
         return bt.config(parser)
 
     def add_args(cls, parser: argparse.ArgumentParser):
-        pass
+        parser.add_argument("--sentry-dsn",type=str,default=None,help="The url that sentry will use to send exception information to")
 
     async def embeddings(self, synapse: Embeddings) -> Embeddings:
         bt.logging.info(f"entered embeddings processing for embeddings of len {len(synapse.texts)}")

--- a/miner/miner.py
+++ b/miner/miner.py
@@ -103,7 +103,7 @@ class StreamMiner():
         self.config = self.config()
         self.config.merge(base_config)
         check_config(StreamMiner, self.config)
-        init_sentry(self.config, {"neuron-type", "miner"})
+        init_sentry(self.config, {"neuron-type": "miner"})
         bt.logging.info(self.config)
         self.prompt_cache: dict[str, Tuple[str, int]] = {}
         self.request_timestamps = {}

--- a/miner/miner.py
+++ b/miner/miner.py
@@ -15,6 +15,7 @@ from functools import partial
 from typing import Tuple
 
 import bittensor as bt
+from cortext.sentry import init_sentry
 import google.generativeai as genai
 import wandb
 from PIL import Image
@@ -101,6 +102,7 @@ class StreamMiner():
         self.config = self.config()
         self.config.merge(base_config)
         check_config(StreamMiner, self.config)
+        init_sentry(self.config, {"neuron-type", "miner"})
         bt.logging.info(self.config)
         self.prompt_cache: dict[str, Tuple[str, int]] = {}
         self.request_timestamps = {}

--- a/miner/miner.py
+++ b/miner/miner.py
@@ -1,4 +1,5 @@
 import argparse
+import sentry_sdk
 import asyncio
 import base64
 import copy
@@ -228,6 +229,7 @@ class StreamMiner():
             return False, f"accepting {synapse_type} request from {hotkey}"
 
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"errror in blacklist {traceback.format_exc()}")
 
 
@@ -316,11 +318,13 @@ class StreamMiner():
                 step += 1
 
         except KeyboardInterrupt:
+            sentry_sdk.capture_exception()
             self.axon.stop()
             bt.logging.success("Miner killed by keyboard interrupt.")
             sys.exit()
 
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(traceback.format_exc())
 
     def run_in_background_thread(self) -> None:
@@ -490,6 +494,7 @@ class StreamMiner():
                     bt.logging.error(f"Unknown provider: {provider}")
 
             except Exception as e:
+                sentry_sdk.capture_exception()
                 bt.logging.error(f"error in _prompt {e}\n{traceback.format_exc()}")
 
         token_streamer = partial(_prompt, synapse)
@@ -560,6 +565,7 @@ class StreamMiner():
             return synapse
 
         except Exception as exc:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"error in images: {exc}\n{traceback.format_exc()}")
 
     async def embeddings(self, synapse: Embeddings) -> Embeddings:
@@ -597,6 +603,7 @@ class StreamMiner():
             bt.logging.info(f"synapse response is {synapse.embeddings[0][:10]}")
             return synapse
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Exception in embeddings function: {traceback.format_exc()}")
 
     async def is_alive(self, synapse: IsAlive) -> IsAlive:
@@ -646,12 +653,14 @@ def get_valid_hotkeys(config):
                         if hotkey not in valid_hotkeys:
                             valid_hotkeys.append(hotkey)
                     except Exception:
+                        sentry_sdk.capture_exception()
                         bt.logging.debug(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
 
             bt.logging.info(f"total valid hotkeys list = {valid_hotkeys}")
             time.sleep(180)
 
         except json.JSONDecodeError as e:
+            sentry_sdk.capture_exception()
             bt.logging.debug(f"JSON decoding error: {e} {run.id}")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ boto3
 anthropic_bedrock
 pyOpenSSL
 google-generativeai
+sentry_sdk==1.44

--- a/start_validator.py
+++ b/start_validator.py
@@ -1,4 +1,5 @@
 import argparse
+import sentry_sdk
 import time
 import subprocess
 import cortext
@@ -46,4 +47,5 @@ if __name__ == "__main__":
     try:
         update_and_restart(args.pm2_name, args.wallet_name, args.wallet_hotkey, args.address, args.autoupdate)
     except Exception as e:
+        sentry_sdk.capture_exception()
         parser.error(f"An error occurred: {e}")

--- a/test_scripts/get_valid_valis.py
+++ b/test_scripts/get_valid_valis.py
@@ -1,4 +1,5 @@
 import os
+import sentry_sdk
 import time
 import wandb
 import json
@@ -64,12 +65,14 @@ def get_valid_hotkeys(config):
                         if hotkey not in valid_hotkeys:
                             valid_hotkeys.append(hotkey)
                     except Exception as e:
+                        sentry_sdk.capture_exception()
                         print(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
 
             print(f"total valid hotkeys list = {valid_hotkeys}")
             time.sleep(180)
 
         except json.JSONDecodeError as e:
+            sentry_sdk.capture_exception()
             print(f"JSON decoding error: {e} {run.id}")
 
 config = get_config()

--- a/test_scripts/t2e/test_embeddings.py
+++ b/test_scripts/t2e/test_embeddings.py
@@ -1,4 +1,5 @@
 import os
+import sentry_sdk
 import random
 import asyncio
 import traceback
@@ -34,6 +35,7 @@ async def embeddings(texts, model):
                 batch_embeddings = [item.embedding for item in response.data]
                 all_embeddings.extend(batch_embeddings)
             except Exception as e:
+                sentry_sdk.capture_exception()
                 bt.logging.error(f"Error in processing batch: {e}")
 
         return all_embeddings
@@ -43,6 +45,7 @@ async def embeddings(texts, model):
         embeddings = [np.array(embed) for embed in batched_embeddings]
         return embeddings
     except Exception as e:
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Exception in embeddings function: {traceback.format_exc()}")
 
 

--- a/test_scripts/t2t/test_gemini.py
+++ b/test_scripts/t2t/test_gemini.py
@@ -1,4 +1,5 @@
 import os
+import sentry_sdk
 import google.generativeai as genai
 import traceback
 import asyncio
@@ -57,6 +58,7 @@ async def call_gemini(messages, temperature, model, max_tokens, top_p, top_k):
         print(stream)
         return stream.text
     except:
+        sentry_sdk.capture_exception()
         print(f"error in call_gemini {traceback.format_exc()}")
 
 # Non streaming
@@ -81,6 +83,7 @@ async def call_gemini(messages, temperature, model, max_tokens, top_p, top_k):
         print(f"validator response is {response.text}")
         return response.text
     except:
+        sentry_sdk.capture_exception()
         print(f"error in call_gemini {traceback.format_exc()}")
 
 async def main():

--- a/test_scripts/t2t/test_openai.py
+++ b/test_scripts/t2t/test_openai.py
@@ -1,4 +1,5 @@
 import asyncio
+import sentry_sdk
 import os
 import traceback
 from openai import OpenAI
@@ -30,6 +31,7 @@ async def send_openai_request(prompt, engine="gpt-4-1106-preview"):
         return all_messages
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         print(f"Got exception when calling openai {e}")
         traceback.print_exc()
         return "Error calling model"

--- a/test_scripts/test_extract_list.py
+++ b/test_scripts/test_extract_list.py
@@ -1,4 +1,5 @@
 import re
+import sentry_sdk
 import os
 import ast
 import math
@@ -126,6 +127,7 @@ def extract_python_list(text: str):
                 return evaluated
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         print(f"Unexpected error when extracting list: {e}\n{traceback.format_exc()}")
 
     return text
@@ -213,6 +215,7 @@ async def call_openai(messages, temperature, model, seed=1234):
             return response
 
         except Exception as e:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Error when calling OpenAI: {e}")
             await asyncio.sleep(0.5) 
     

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,4 +1,5 @@
 import requests
+import sentry_sdk
 import websocket
 
 from test_base import ActiveSubnetworkBaseTest
@@ -14,6 +15,7 @@ class Test(ActiveSubnetworkBaseTest):
         try:
             requests.get(f'http://localhost:{VALIDATOR_PORT}/', timeout=1)
         except requests.RequestException:
+            sentry_sdk.capture_exception()
             return False
         return True
 
@@ -22,6 +24,7 @@ class Test(ActiveSubnetworkBaseTest):
         try:
             websocket.create_connection(f'ws://localhost:{AXON_PORT}', timeout=1)
         except ConnectionRefusedError:
+            sentry_sdk.capture_exception()
             return False
         except websocket.WebSocketBadStatusException:
             return True

--- a/validators/base_validator.py
+++ b/validators/base_validator.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+import sentry_sdk
 import bittensor as bt
 
 
@@ -19,6 +20,7 @@ class BaseValidator(ABC):
             return await self.handle_response(uid, responses)
 
         except Exception as e:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Exception during query for uid {uid}: {e}")
             return uid, None
 

--- a/validators/text_validator.py
+++ b/validators/text_validator.py
@@ -1,4 +1,5 @@
 import asyncio
+import sentry_sdk
 import random
 import traceback
 from typing import AsyncIterator, Tuple
@@ -114,6 +115,7 @@ class TextValidator(BaseValidator):
             query_responses = await asyncio.gather(*query_tasks)
             return query_responses, uid_to_question
         except:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"error in start_query = {traceback.format_exc()}")
 
     def should_i_score(self):

--- a/validators/validator.py
+++ b/validators/validator.py
@@ -1,4 +1,5 @@
 import logging
+import sentry_sdk
 import time
 from typing import Tuple
 
@@ -131,6 +132,7 @@ def main(test=False) -> None:
     try:
         loop.run_forever()
     except KeyboardInterrupt:
+        sentry_sdk.capture_exception()
         bt.logging.info("Keyboard interrupt detected. Exiting validator.")
     finally:
         state = utils.get_state(state_path)

--- a/validators/validator.py
+++ b/validators/validator.py
@@ -115,7 +115,7 @@ def initialize_validators(vali_config, test=False):
 
 def main(test=False) -> None:
     config = get_config()
-    init_sentry(config, {"neuron-type", "validator"})
+    init_sentry(config, {"neuron-type": "validator"})
     wallet, subtensor, dendrite, my_uid = initialize_components(config)
     validator_config = {
         "dendrite": dendrite,

--- a/validators/validator.py
+++ b/validators/validator.py
@@ -12,6 +12,7 @@ import traceback
 from pathlib import Path
 
 import bittensor as bt
+from cortext.sentry import init_sentry
 import torch
 import wandb
 from image_validator import ImageValidator
@@ -38,6 +39,8 @@ def get_config() -> bt.config:
     parser.add_argument("--netuid", type=int, default=18)
     parser.add_argument('--wandb_off', action='store_false', dest='wandb_on')
     parser.add_argument('--axon.port', type=int, default=8000)
+    parser.add_argument("--sentry-dsn",type=str,default=None,help="The url that sentry will use to send exception information to")
+
     parser.set_defaults(wandb_on=True)
     bt.subtensor.add_args(parser)
     bt.logging.add_args(parser)
@@ -111,6 +114,7 @@ def initialize_validators(vali_config, test=False):
 
 def main(test=False) -> None:
     config = get_config()
+    init_sentry(config, {"neuron-type", "validator"})
     wallet, subtensor, dendrite, my_uid = initialize_components(config)
     validator_config = {
         "dendrite": dendrite,

--- a/validators/weight_setter.py
+++ b/validators/weight_setter.py
@@ -1,4 +1,5 @@
 import asyncio
+import sentry_sdk
 import concurrent
 import itertools
 import traceback
@@ -118,6 +119,7 @@ class WeightSetter:
             return True, f"rejecting {synapse_type} request from {hotkey}"
 
         except Exception:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"errror in blacklist {traceback.format_exc()}")
 
     async def images(self, synapse: ImageResponse) -> ImageResponse:
@@ -219,6 +221,7 @@ class WeightSetter:
                 else:
                     await asyncio.sleep(60)
             except Exception as e:
+                sentry_sdk.capture_exception()
                 bt.logging.error(f'Encountered in {self.consume_organic_scoring.__name__} loop:\n{traceback.format_exc()}')
                 await asyncio.sleep(10)
                 
@@ -270,6 +273,7 @@ class WeightSetter:
             return None
 
         except Exception as e:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"Error checking UID {uid}: {e}\n{traceback.format_exc()}")
             return None
 


### PR DESCRIPTION
This PR integrates [sentry](https://sentry.io) into the subnet's code.

Sentry is a toolkit that captures exceptions and sends all relevant information to a central server, where this information can be viewed in a dashboard. Sentry can integrate with github, so problems can be triaged, and allocated to teammembers.

![image](https://github.com/corcel-api/cortex.t/assets/8060851/fe11364f-1e09-4a36-945e-2d47819f0409)



All except statements have been hooked, as to create a full overview what is going wrong in the codebase. This means you will get unhandled (really bad) and handled exceptions (maybe bad). The unhandled ones should be resolved first, as this is a script breaking. The handled ones allow you to see if any weird stuff is happening. If the issue is not weird at all, those events can be muted in the dashboard.

In order to get this running, you will need to create an account and create a project. You will be given a trial first, then you'll need to select a paid plan or you'll get busted to the "Developer plan". This project will give you a dsn. Both validator and miner can be started with the `--sentry-dsn <dsn>` parameter. When this flag is enabled, sentry is enabled and will start sending information to the server.

You can  choose to withhold the dns and only run it in a test-net. However, if you make the dsn public, all participants in the network that specify the parameter will report error information. This should allow you to quickly react to fatal problems and put out patches.


I have hooked all my validators in a similar fashion, but I get so many exceptions that I can't really all SN owners of the problems, so it makes more sense to have the SN owners handled this themselves.

Note, this PR has been tested for validator only. As I don't run any miners, this should be verified for miners as well.


If you feel this PR is worthy of a reward, TAO's can go to `5FZ3Cyq4wNX6rgiTD6kSEovZ6hcvcej6N3uwV68ELb6vwQo4`

Greets,
Your trusty l0lpusher69 



